### PR TITLE
Uploading converts åäö and other characters to HTML entities

### DIFF
--- a/Support/assets/upload.php
+++ b/Support/assets/upload.php
@@ -7,7 +7,7 @@ if(is_binary(getenv('TM_FILEPATH'))) {
     exit();
 }
 
-$filecontents = htmlentities(file_get_contents('php://stdin'), ENT_QUOTES, 'UTF-8');
+$filecontents = htmlspecialchars(file_get_contents('php://stdin'), ENT_QUOTES, 'UTF-8');
 $reqData = sprintf($xmlDataTemp, $filecontents, $assetKey);
 
 //Dump the xml into a tmp file

--- a/Support/assets/upload_multi.php
+++ b/Support/assets/upload_multi.php
@@ -20,7 +20,7 @@ foreach ($selectedFiles as $file) {
         $filecontents = base64_encode(file_get_contents($file));
         $reqData = sprintf($xmlDataTempImage, $filecontents, $assetKey);
     } else {
-        $filecontents = htmlentities(file_get_contents($file), ENT_QUOTES, 'UTF-8');
+        $filecontents = htmlspecialchars(file_get_contents($file), ENT_QUOTES, 'UTF-8');
         $reqData = sprintf($xmlDataTemp, $filecontents, $assetKey);
     }
 


### PR DESCRIPTION
When uploading stuff all special characters get converted into HTML entities in the upload process. ä for example gets converted into &auml;

For html files you notice it as you get changes in your commits when you pull the whole theme from shopify to sync work that someone has done via the web interface. Not too annoying. It's worse for javascript where it bugs out when inserting strings into the page. This makes the html entity visible instead of the desired character.

The attached diff fixed the problem for me.
