### PR TITLE
Support for multiple themes, such as the mobile theme.

### DIFF
--- a/Commands/Download Theme.tmCommand
+++ b/Commands/Download Theme.tmCommand
@@ -29,8 +29,14 @@ require_once TM_BUNDLE_SUPPORT.DIRECTORY_SEPARATOR.'functions.php';
 
 //Request Asset URL Template
 // %1: API KEY, %2: PASSWORD, %3: STORE, %4: ASSET NAME
-$requestUrlTemp = 'http://%1$s:%2$s@%3$s/admin/assets.json';
-$requestUrl = sprintf($requestUrlTemp, $api_key, $password, $store);
+if ($theme_id == "") {
+  $requestUrlTemp = 'http://%1$s:%2$s@%3$s/admin/assets.json';
+  $requestUrl = sprintf($requestUrlTemp, $api_key, $password, $store);
+}
+else {
+  $requestUrlTemp = 'http://%1$s:%2$s@%3$s/admin/themes/%4$s/assets.json';
+  $requestUrl = sprintf($requestUrlTemp, $api_key, $password, $store, $theme_id);
+}
 
 // yes, I am aware php has curl. This is just simpler.
 echo "Getting theme asset list...&lt;br&gt;";
@@ -67,7 +73,7 @@ foreach ($assetFiles as $file) {
     }
 
     echo "Fetching {$file}...&lt;br&gt;";
-    $asset = get_asset($api_key, $password, $store, $file);
+    $asset = get_asset($api_key, $password, $store, $theme_id, $file);
     
     if(false === $asset) {
         echo "*Error fetching: ($file)&lt;br&gt;";

--- a/Commands/Get Rendered CSS file from _css_liquid.tmCommand
+++ b/Commands/Get Rendered CSS file from _css_liquid.tmCommand
@@ -36,7 +36,7 @@ if(false !== strpos($filepath, '.css.liquid')) {
 
 echo "Fetching {$filepath}...&lt;br&gt;";
 
-$asset = get_asset($api_key, $password, $store, $filepath);
+$asset = get_asset($api_key, $password, $store, $theme_id, $filepath);
 
 if(false == $asset) { //Do Nothing.
     echo '*Error: Could not get '. $filepath .'&lt;br&gt;';

--- a/Commands/Remove Selected Assets from Shopify.tmCommand
+++ b/Commands/Remove Selected Assets from Shopify.tmCommand
@@ -37,7 +37,7 @@ foreach ($selectedFiles as $file) {
     $assetKey = calc_asset_key($file);
     echo "Removing $assetKey... ";
     
-    if(remove_asset($api_key, $password, $store, $assetKey)) {
+    if(remove_asset($api_key, $password, $store, $theme_id, $assetKey)) {
         echo "removed¡&lt;br&gt;";
     }
     else {

--- a/Commands/Update Selected Files From Shopify.tmCommand
+++ b/Commands/Update Selected Files From Shopify.tmCommand
@@ -36,7 +36,7 @@ foreach ($selectedFiles as $file) {
     $assetKey = calc_asset_key($file);
     echo "Fetching {$assetKey}...&lt;br&gt;";
     
-    $asset = get_asset($api_key, $password, $store, $assetKey);
+    $asset = get_asset($api_key, $password, $store, $theme_id, $assetKey);
 
     if(false == $asset) { //Do Nothing.
         echo '*Error: Could not update asset '. $assetKey .'&lt;br&gt;';

--- a/Commands/Update Template From Shopify.tmCommand
+++ b/Commands/Update Template From Shopify.tmCommand
@@ -27,7 +27,7 @@ require_once TM_BUNDLE_SUPPORT.DIRECTORY_SEPARATOR.'functions.php';
 // File path, based on theme restriction of no nested folder, so we make certain assumptions
 $filepath = calc_asset_key(getenv('TM_FILEPATH')); 
 
-$asset = get_asset($api_key, $password, $store, $filepath);
+$asset = get_asset($api_key, $password, $store, $theme_id, $filepath);
 
 // clean out the \r 's - mac uses \n only. 
 if(false !== $asset &amp;&amp; property_exists($asset, 'value')) {

--- a/Support/assets/upload.php
+++ b/Support/assets/upload.php
@@ -14,7 +14,7 @@ $reqData = sprintf($xmlDataTemp, $filecontents, $assetKey);
 $xmlFile = tempnam('/tmp', 'foo').'.xml';
 file_put_contents($xmlFile, $reqData);
 
-$response = send_asset($api_key, $password, $store ,$xmlFile);
+$response = send_asset($api_key, $password, $store , $theme_id, $xmlFile);
 
 if('200' == $response) {
     echo "Uploaded {$assetKey} to {$config->current}.";

--- a/Support/assets/upload_multi.php
+++ b/Support/assets/upload_multi.php
@@ -29,7 +29,7 @@ foreach ($selectedFiles as $file) {
     file_put_contents($xmlFile, $reqData);
 
     echo "Sending asset: {$assetKey}...<br>";
-    $response = send_asset($api_key, $password, $store ,$xmlFile);
+    $response = send_asset($api_key, $password, $store , $theme_id, $xmlFile);
 
     if('200' == $response) {
         echo "Uploaded: {$assetKey}<br>";

--- a/Support/config.php
+++ b/Support/config.php
@@ -18,6 +18,8 @@ class mConfig {
     
     var $store = null;
     
+    var $theme_id = null;
+    
     //Used to output to user what shop they are pushing to. Reads better than full shop name.
     var $current = 'default';
     
@@ -33,6 +35,7 @@ class mConfig {
             $this->api_key  = getenv('SHOPIFY_API_KEY');
             $this->password = getenv('SHOPIFY_PASSWORD');
             $this->store    = getenv('SHOPIFY_STORE');
+            $this->theme_id = getenv('SHOPIFY_THEME_ID');
 
             if( (!$this->api_key) || (!$this->password) || (!$this->store) ) {
                 echo "No config file found here: {$path} ?";

--- a/Support/functions.php
+++ b/Support/functions.php
@@ -58,12 +58,19 @@ function output_error($response, $options = array()) {
  * @param string $key Key of asset we are downloading
  * @return object Asset / false on failure
  **/
-function get_asset($api_key, $password, $store, $key) {
+function get_asset($api_key, $password, $store, $theme_id, $key) {
     //Request Asset URL Template
     // %1: API KEY, %2: PASSWORD, %3: STORE, %4: ASSET NAME
-    $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/assets.json?asset[key]=%4$s',
-                    $api_key, $password, $store, $key
-                );
+    if ($theme_id == "") {
+        $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/assets.json?asset[key]=%4$s',
+                        $api_key, $password, $store, $key
+                    );
+    }
+    else {
+        $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/themes/%4$s/assets.json?asset[key]=%5$s',
+                        $api_key, $password, $store, $theme_id, $key
+                    );
+    }
 
     $responseTxt = `curl -s -g '$requestUrl'`;
     $response = json_decode($responseTxt);
@@ -83,11 +90,18 @@ function get_asset($api_key, $password, $store, $key) {
  * @param string $xmlFile Path to the XML File with the contents to upload.
  * @return string
  **/
-function send_asset($api_key, $password, $store ,$xmlFile) {
+function send_asset($api_key, $password, $store, $theme_id, $xmlFile) {
 
-    $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/assets.xml', 
-            $api_key, $password, $store
-        );
+    if ($theme_id == "") {
+      $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/assets.xml', 
+              $api_key, $password, $store
+          );
+    }
+    else {
+      $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/themes/%4$s/assets.xml', 
+              $api_key, $password, $store, $theme_id
+          );
+    }
 
     // Right now, not bothering with dumping the full response/error handling. Will add if it becomes an issue. 
     //We just collect the http_code and will display message if it's Not 200
@@ -105,12 +119,19 @@ function send_asset($api_key, $password, $store ,$xmlFile) {
  * @param string $key Key of asset we are downloading
  * @return object Asset / false on failure
  **/
-function remove_asset($api_key, $password, $store, $key) {
+function remove_asset($api_key, $password, $store, $theme_id, $key) {
     //Request Asset URL Template
     // %1: API KEY, %2: PASSWORD, %3: STORE, %4: ASSET NAME
-    $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/assets.json?asset[key]=%4$s',
-                    $api_key, $password, $store, $key
-                );
+    if ($theme_id == "") {
+      $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/assets.json?asset[key]=%4$s',
+                      $api_key, $password, $store, $key
+                  );
+    }
+    else {
+      $requestUrl = sprintf('http://%1$s:%2$s@%3$s/admin/themes/%4$s/assets.json?asset[key]=%5$s',
+                      $api_key, $password, $store, $theme_id, $key
+                  );
+    }
                 
     $response = json_decode(`curl -w'%{http_code}' -X DELETE -s -g '$requestUrl'`);
 

--- a/Support/vars.php
+++ b/Support/vars.php
@@ -7,6 +7,7 @@ $config = new mConfig(CONFIG_FILE_PATH);
 $api_key = $config->api_key;    //getenv('SHOPIFY_API_KEY');
 $password = $config->password;  //getenv('SHOPIFY_PASSWORD');
 $store = $config->store;        //getenv('SHOPIFY_STORE');
+$theme_id = $config->theme_id;
 
 define('TM_PROJECT_DIRECTORY',getenv('TM_PROJECT_DIRECTORY'));
 


### PR DESCRIPTION
Support multiple themes, such as Shopify's new Mobile theme support or work on a duplicated theme. Just set a SHOPIFY_THEME_ID like the other variables. Get the SHOPIFY_THEME_ID by looking at the URL from the template editor on your admin page.
