### PR TITLE
Show additional errors

### DIFF
--- a/Commands/Download Theme.tmCommand
+++ b/Commands/Download Theme.tmCommand
@@ -8,6 +8,12 @@
 	<string>#!/usr/bin/env php
 &lt;?php
 
+// If there isn't a project directory there's no folder to download to.
+if (is_null($_ENV['TM_PROJECT_DIRECTORY'])) {
+    echo "Error: You may only download a theme to a project folder. Create a project folder in TextMate and try again.";
+    die();
+}
+
 //Kinda sucks, but this will need to be in each script, as opposed to be loaded
 //Make some assumptions if running under windows. 
 //This is for compat with Environment: Cygwin generic mode, which gives us access to curl

--- a/Commands/Pages: Download All.tmCommand
+++ b/Commands/Pages: Download All.tmCommand
@@ -9,6 +9,14 @@
 # Setting up new framework based on what i've learnt working on a new project
 # this file is just a test for it
 source "$TM_SUPPORT_PATH/lib/bash_init.sh"
+
+# If there isn't a project directory there's no folder to download to.
+if [ -z $TM_PROJECT_DIRECTORY ]
+then
+    echo "Error: You may only download the pages to a project folder. Create the a project folder in TextMate and try again."
+    exit
+fi
+
 "$TM_BUNDLE_SUPPORT/runner.php" pages download_all
 rescan_project</string>
 	<key>input</key>


### PR DESCRIPTION
Ran into problems using it for the first time. I set the shopify variables in TextMate's preferences, and when I ran the download theme command it spit out a ton of errors about permissions and incapable of finding folders because it had no project folder to download to.

So, I made changes to Download Theme and Pages: Download All where it would show an error explaining that there needs to be a project folder to download to. :)
